### PR TITLE
fix: rename FastMCP `prompt` parameter to `instructions`

### DIFF
--- a/src/bocha_search_mcp/server.py
+++ b/src/bocha_search_mcp/server.py
@@ -14,7 +14,7 @@ load_dotenv()
 # Initialize FastMCP server
 server = FastMCP(
     "bocha-search-mcp",
-    prompt="""
+    instructions="""
 # Bocha Search MCP Server
                  
 Bocha is a Chinese search engine for AI, This server provides tools for searching the web using Bocha Search API.


### PR DESCRIPTION
## Problem

`FastMCP.__init__()` no longer accepts a `prompt` keyword argument as of `mcp >= 1.6.0` (the minimum version declared in `pyproject.toml`). Running the server with the current code raises:

```
TypeError: FastMCP.__init__() got an unexpected keyword argument 'prompt'
```

The server cannot start at all.

## Fix

Rename `prompt=` to `instructions=` on line 17 of `server.py` — one character change, matching the current FastMCP API.

## Verification

Tested with `mcp[cli]==1.6.0`:
- Before: server crashes immediately with `TypeError`
- After: server starts, connects, and tools return results correctly