### PR TITLE
fix(server): use `instructions=` instead of `prompt=` for FastMCP

### DIFF
--- a/src/bocha_search_mcp/server.py
+++ b/src/bocha_search_mcp/server.py
@@ -14,7 +14,7 @@ load_dotenv()
 # Initialize FastMCP server
 server = FastMCP(
     "bocha-search-mcp",
-    prompt="""
+    instructions="""
 # Bocha Search MCP Server
                  
 Bocha is a Chinese search engine for AI, This server provides tools for searching the web using Bocha Search API.


### PR DESCRIPTION
## Summary

`FastMCP.__init__()` in `mcp[cli] >= 1.6.0` (the version pinned in `pyproject.toml`) does not accept a `prompt` keyword argument — it accepts `instructions`. With the current `master`, the server fails to start at import time with a `TypeError`, so the published server is essentially unusable on a fresh install.

## Reproduction

```bash
git clone https://github.com/BochaAI/bocha-search-mcp
cd bocha-search-mcp
BOCHA_API_KEY=sk-xxx uv run bocha-search-mcp
```

Result:

```
Traceback (most recent call last):
  File ".../bocha_search_mcp/__init__.py", line 1, in <module>
    from bocha_search_mcp.server import server
  File ".../bocha_search_mcp/server.py", line 15, in <module>
    server = FastMCP(
             ^^^^^^^^
TypeError: FastMCP.__init__() got an unexpected keyword argument 'prompt'
```

The PyPI release `bocha-search-mcp==0.0.1` has the same defect.

## Fix

Rename the kwarg from `prompt=` to `instructions=`. The string content is unchanged; it now surfaces as the `instructions` field of the server-info payload returned to clients on `initialize`, which is the standard MCP mechanism for server-level guidance.

## Verification

After the patch, an `initialize` JSON-RPC request returns a valid response and both tools (`bocha_web_search`, `bocha_ai_search`) appear in `tools/list`. Tested against Claude Desktop 2026 (protocolVersion `2025-11-25`) — the server negotiates back to `2024-11-05` and the connection completes successfully.

## Test plan
- [x] `uv run bocha-search-mcp` starts without TypeError
- [x] `initialize` request returns `serverInfo` + `instructions` field with the original prompt text
- [x] `tools/list` returns both tools
- [ ] Maintainer to re-test against any internal CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)